### PR TITLE
Allow outbound DNS requests from Lambda SG

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -121,6 +121,26 @@ resource "aws_security_group" "default" {
   tags        = "${module.label.tags}"
 }
 
+resource "aws_security_group_rule" "udp_dns_egress_from_lambda" {
+  description       = "Allow outbound UDP traffic from Lambda Elasticsearch cleanup to DNS"
+  type              = "egress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "udp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.default.id}"
+}
+
+resource "aws_security_group_rule" "tcp_dns_egress_from_lambda" {
+  description       = "Allow outbound TCP traffic from Lambda Elasticsearch cleanup to DNS"
+  type              = "egress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.default.id}"
+}
+
 resource "aws_security_group_rule" "egress_from_lambda_to_es_cluster" {
   description              = "Allow outbound traffic from Lambda Elasticsearch cleanup SG to Elasticsearch SG"
   type                     = "egress"


### PR DESCRIPTION
## what

Allow outbound DNS requests from Lambda SG 

## why
So that we can resolve DNS for the ES cluster. Not sure why this was not required during testing, possibly because of private route53 DNS vs not. Currently the Lambda function is hitting the timeout trying to resolve DNS.