### PR TITLE
Add enabled flag, fix IAM permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 ## Usage
 
+
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
+Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-lambda-elasticsearch-cleanup/releases).
+
+
 ```hcl
 module "elasticsearch_cleanup" {
   source               = "../"
@@ -92,6 +97,7 @@ is given
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | delete_after | Number of days to preserve | string | `15` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
+| enabled | This module will not create any resources unless enabled is set to "true" | string | `true` | no |
 | es_domain_arn | The Elasticsearch domain ARN | string | - | yes |
 | es_endpoint | The Elasticsearch endpoint for the Lambda function to connect to | string | - | yes |
 | es_security_group_id | The Elasticsearch cluster security group ID | string | - | yes |
@@ -196,7 +202,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2018 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -12,6 +12,7 @@ is given
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | delete_after | Number of days to preserve | string | `15` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
+| enabled | This module will not create any resources unless enabled is set to "true" | string | `true` | no |
 | es_domain_arn | The Elasticsearch domain ARN | string | - | yes |
 | es_endpoint | The Elasticsearch endpoint for the Lambda function to connect to | string | - | yes |
 | es_security_group_id | The Elasticsearch cluster security group ID | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "default" {
     effect = "Allow"
 
     resources = [
-      "${var.es_domain_arn}",
+      "${var.es_domain_arn}/*",
     ]
   }
 }
@@ -88,6 +88,7 @@ locals {
 # Resources
 #--------------------------------------------------------------
 resource "aws_lambda_function" "default" {
+  count            = "${var.enabled == "true" ? 1 : 0}"
   filename         = "${module.artifact.file}"
   function_name    = "${local.function_name}"
   description      = "${local.function_name}"
@@ -115,6 +116,7 @@ resource "aws_lambda_function" "default" {
 }
 
 resource "aws_security_group" "default" {
+  count       = "${var.enabled == "true" ? 1 : 0}"
   name        = "${local.function_name}"
   description = "${local.function_name}"
   vpc_id      = "${var.vpc_id}"
@@ -122,6 +124,7 @@ resource "aws_security_group" "default" {
 }
 
 resource "aws_security_group_rule" "udp_dns_egress_from_lambda" {
+  count             = "${var.enabled == "true" ? 1 : 0}"
   description       = "Allow outbound UDP traffic from Lambda Elasticsearch cleanup to DNS"
   type              = "egress"
   from_port         = 53
@@ -132,6 +135,7 @@ resource "aws_security_group_rule" "udp_dns_egress_from_lambda" {
 }
 
 resource "aws_security_group_rule" "tcp_dns_egress_from_lambda" {
+  count             = "${var.enabled == "true" ? 1 : 0}"
   description       = "Allow outbound TCP traffic from Lambda Elasticsearch cleanup to DNS"
   type              = "egress"
   from_port         = 53
@@ -142,6 +146,7 @@ resource "aws_security_group_rule" "tcp_dns_egress_from_lambda" {
 }
 
 resource "aws_security_group_rule" "egress_from_lambda_to_es_cluster" {
+  count                    = "${var.enabled == "true" ? 1 : 0}"
   description              = "Allow outbound traffic from Lambda Elasticsearch cleanup SG to Elasticsearch SG"
   type                     = "egress"
   from_port                = 443
@@ -152,6 +157,7 @@ resource "aws_security_group_rule" "egress_from_lambda_to_es_cluster" {
 }
 
 resource "aws_security_group_rule" "ingress_to_es_cluster_from_lambda" {
+  count                    = "${var.enabled == "true" ? 1 : 0}"
   description              = "Allow inbound traffic to Elasticsearch domain from Lambda Elasticsearch cleanup SG"
   type                     = "ingress"
   from_port                = 443
@@ -162,29 +168,34 @@ resource "aws_security_group_rule" "ingress_to_es_cluster_from_lambda" {
 }
 
 resource "aws_iam_role" "default" {
+  count              = "${var.enabled == "true" ? 1 : 0}"
   name               = "${local.function_name}"
   assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
   tags               = "${module.label.tags}"
 }
 
 resource "aws_iam_role_policy" "default" {
+  count  = "${var.enabled == "true" ? 1 : 0}"
   name   = "${local.function_name}"
   role   = "${aws_iam_role.default.name}"
   policy = "${data.aws_iam_policy_document.default.json}"
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
+  count      = "${var.enabled == "true" ? 1 : 0}"
   role       = "${aws_iam_role.default.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_cloudwatch_event_rule" "default" {
+  count               = "${var.enabled == "true" ? 1 : 0}"
   name                = "${local.function_name}"
   description         = "${local.function_name}"
   schedule_expression = "${var.schedule}"
 }
 
 resource "aws_lambda_permission" "default" {
+  count         = "${var.enabled == "true" ? 1 : 0}"
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
   function_name = "${aws_lambda_function.default.arn}"
@@ -193,6 +204,7 @@ resource "aws_lambda_permission" "default" {
 }
 
 resource "aws_cloudwatch_event_target" "default" {
+  count     = "${var.enabled == "true" ? 1 : 0}"
   target_id = "${local.function_name}"
   rule      = "${aws_cloudwatch_event_rule.default.name}"
   arn       = "${aws_lambda_function.default.arn}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "security_group_id" {
-  value       = "${aws_security_group.default.id}"
+  value       = "${join(",",aws_security_group.default.*.id)}"
   description = "Security Group ID of the Lambda "
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "enabled" {
+  type        = "string"
+  default     = "true"
+  description = "This module will not create any resources unless enabled is set to \"true\""
+}
+
 variable "es_endpoint" {
   type        = "string"
   description = "The Elasticsearch endpoint for the Lambda function to connect to"


### PR DESCRIPTION
## what
- Add `enabled` flag
- Fix IAM permissions for lambda role
## why
- Allow module to be included in other module but disabled by variable
- Allow proper operation with a protected AWS Elasticsearch domain