### PR TITLE
Use relative file path of lambda rather than absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ is given
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |
 | python_version | The Python version to use | string | `2.7` | no |
 | schedule | CloudWatch Events rule schedule using cron or rate expression | string | `cron(0 3 * * ? *)` | no |
-| sns_arn | SNS ARN to pusblish alerts | string | `` | no |
+| sns_arn | SNS ARN to publish alerts | string | `` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | - | yes |
 | subnet_ids | Subnet ids | list | - | yes |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | map | `<map>` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -22,7 +22,7 @@ is given
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |
 | python_version | The Python version to use | string | `2.7` | no |
 | schedule | CloudWatch Events rule schedule using cron or rate expression | string | `cron(0 3 * * ? *)` | no |
-| sns_arn | SNS ARN to pusblish alerts | string | `` | no |
+| sns_arn | SNS ARN to publish alerts | string | `` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | - | yes |
 | subnet_ids | Subnet ids | list | - | yes |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | map | `<map>` | no |

--- a/lambda/COPYRIGHT.md
+++ b/lambda/COPYRIGHT.md
@@ -1,0 +1,17 @@
+Files in this directory may be subject to the following notice:
+
+Apache Software License 2.0
+
+Copyright 2016 **Cloudreach Europe Limited** or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ module "artifact" {
   source      = "git::https://github.com/cloudposse/terraform-external-module-artifact.git?ref=tags/0.1.1"
   filename    = "lambda.zip"
   module_name = "terraform-aws-lambda-elasticsearch-cleanup"
-  module_path = "${path.module}"
+  module_path = "${substr(path.module, length(path.cwd) + 1, -1)}"
 }
 
 # Locals

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "subnet_ids" {
 variable "sns_arn" {
   type        = "string"
   default     = ""
-  description = "SNS ARN to pusblish alerts"
+  description = "SNS ARN to publish alerts"
 }
 
 variable "index" {


### PR DESCRIPTION
## what
Refer to the `lambda.zip` file by path relative to `cwd` rather than absolute path

## why
Atlantis uses a different absolute pathname for every pull request, and we want to have a consistent filename. 