### PR TITLE
Match .kibana index and don't clean them up

### DIFF
--- a/lambda/es-cleanup.py
+++ b/lambda/es-cleanup.py
@@ -186,8 +186,8 @@ def lambda_handler(event, context):
         earliest_to_keep = datetime.date.today() - datetime.timedelta(
             days=int(es.cfg["delete_after"]))
         for index in es.get_indices():
-            if index["index"] == ".kibana":
-                # ignore .kibana index
+            if re.match(r'^.kibana', index["index"]):
+            # ignore .kibana & .kibana_N indices
                 print("Found .kibana index - ignoring")
                 continue
 


### PR DESCRIPTION
From version 6.5.0 kibana indexes are being stored as .kibana_1 .. kibana_N
Hence regexmatching indexes which start as .kibana, as with the current approach they get deleted and you lose your saved objects
https://www.elastic.co/guide/en/kibana/current/upgrade-migrations.html