### PR TITLE
Update to work with updated AWS requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,6 @@ Available targets:
   lint                                Lint terraform code
 
 ```
-## Module: cloudposse/terraform-aws-lambda-elasticsearch-cleanup
-
-This module creates a scheduled Lambda function which will delete old
-Elasticsearch indexes using SigV4Auth authentication. The lambda
-function can optionally send output to an SNS topic if the topic ARN
-is given
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -101,7 +94,7 @@ is given
 | es_domain_arn | The Elasticsearch domain ARN | string | - | yes |
 | es_endpoint | The Elasticsearch endpoint for the Lambda function to connect to | string | - | yes |
 | es_security_group_id | The Elasticsearch cluster security group ID | string | - | yes |
-| index | Index/indices to process. Use a comma-separated list. Specify `all` to match every index except for `.kibana` | string | `all` | no |
+| index | Index/indices to process. Use a comma-separated list. Specify `all` to match every index except for `.kibana` or `.kibana_1` | string | `all` | no |
 | index_format | Combined with 'index' variable and is used to evaluate the index age | string | `%Y.%m.%d` | no |
 | name | Solution name, e.g. 'app' or 'cluster' | string | `app` | no |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,10 +1,3 @@
-## Module: cloudposse/terraform-aws-lambda-elasticsearch-cleanup
-
-This module creates a scheduled Lambda function which will delete old
-Elasticsearch indexes using SigV4Auth authentication. The lambda
-function can optionally send output to an SNS topic if the topic ARN
-is given
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -16,7 +9,7 @@ is given
 | es_domain_arn | The Elasticsearch domain ARN | string | - | yes |
 | es_endpoint | The Elasticsearch endpoint for the Lambda function to connect to | string | - | yes |
 | es_security_group_id | The Elasticsearch cluster security group ID | string | - | yes |
-| index | Index/indices to process. Use a comma-separated list. Specify `all` to match every index except for `.kibana` | string | `all` | no |
+| index | Index/indices to process. Use a comma-separated list. Specify `all` to match every index except for `.kibana` or `.kibana_1` | string | `all` | no |
 | index_format | Combined with 'index' variable and is used to evaluate the index age | string | `%Y.%m.%d` | no |
 | name | Solution name, e.g. 'app' or 'cluster' | string | `app` | no |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |

--- a/lambda/es-cleanup.py
+++ b/lambda/es-cleanup.py
@@ -2,6 +2,9 @@
 # -*- coding: utf-8 -*-
 """
 This AWS Lambda function allowed to delete the old Elasticsearch index
+
+THIS FILE IS NOT EXACTLY THE ORIGINAL FILE DISTRIBUTED BY Cloudreach Europe Limited
+IT HAS BEEN MODIFIED BY Cloud Posse, LLC
 """
 
 from __future__ import print_function
@@ -14,8 +17,8 @@ import datetime
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from botocore.credentials import create_credential_resolver
+from botocore.httpsession import URLLib3Session
 from botocore.session import get_session
-from botocore.vendored.requests import Session
 import sys
 if sys.version_info[0] == 3:
     from urllib.request import quote
@@ -117,7 +120,7 @@ class ES_Cleanup(object):
 
             try:
                 preq = req.prepare()
-                session = Session()
+                session = URLLib3Session()
                 res = session.send(preq)
                 if res.status_code >= 200 and res.status_code <= 299:
                     # print("%s %s" % (res.status_code, res.content))
@@ -186,9 +189,9 @@ def lambda_handler(event, context):
         earliest_to_keep = datetime.date.today() - datetime.timedelta(
             days=int(es.cfg["delete_after"]))
         for index in es.get_indices():
-            if index["index"] == ".kibana":
+            if index["index"] == ".kibana" or index["index"] == ".kibana_1":
                 # ignore .kibana index
-                print("Found .kibana index - ignoring")
+                print("Found Kibana index: %s - ignoring" % index["index"])
                 continue
 
             idx_name = '-'.join(word for word in index["index"].split("-")[:-1])

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,7 @@ variable "sns_arn" {
 variable "index" {
   type        = "string"
   default     = "all"
-  description = "Index/indices to process. Use a comma-separated list. Specify `all` to match every index except for `.kibana`"
+  description = "Index/indices to process. Use a comma-separated list. Specify `all` to match every index except for `.kibana` or `.kibana_1`"
 }
 
 variable "delete_after" {


### PR DESCRIPTION
## what
- Incorporate https://github.com/cloudreach/aws-lambda-es-cleanup/pull/30

## why
- Fix `ValueError: You can only send PreparedRequests` (See https://github.com/cloudreach/aws-lambda-es-cleanup/issues/29)