### PR TITLE
Make SNS optional again

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "assume_role" {
   }
 }
 
-data "aws_iam_policy_document" "default" {
+data "aws_iam_policy_document" "es_logs" {
   statement {
     actions = [
       "logs:CreateLogGroup",
@@ -57,7 +57,9 @@ data "aws_iam_policy_document" "default" {
       "${var.es_domain_arn}/*",
     ]
   }
+}
 
+data "aws_iam_policy_document" "sns" {
   statement {
     actions = [
       "sns:Publish",
@@ -69,6 +71,11 @@ data "aws_iam_policy_document" "default" {
       "${var.sns_arn}",
     ]
   }
+}
+
+data "aws_iam_policy_document" "default" {
+  source_json   = "${data.aws_iam_policy_document.es_logs.json}"
+  override_json = "${length(var.sns_arn) > 0 ? data.aws_iam_policy_document.sns.json : "{}"}"
 }
 
 # Modules

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "security_group_id" {
-  value       = "${join(",",aws_security_group.default.*.id)}"
+  value       = "${join(",", aws_security_group.default.*.id)}"
   description = "Security Group ID of the Lambda "
 }


### PR DESCRIPTION
## what
Supplying an `sns_arn` is supposed to be optional, but #11 made it a requirement because it generated an invalid IAM policy without one. This makes it optional again.

## why
SNS notifications are not necessary for this lambda to do its primary job.