### PR TITLE
Update `terraform-external-module-artifact` version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,6 +76,7 @@ data "aws_iam_policy_document" "default" {
 #--------------------------------------------------------------
 module "label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  enabled    = var.enabled
   namespace  = var.namespace
   name       = var.name
   stage      = var.stage
@@ -85,7 +86,8 @@ module "label" {
 }
 
 module "artifact" {
-  source      = "git::https://github.com/cloudposse/terraform-external-module-artifact.git?ref=tags/0.2.0"
+  #source      = "git::https://github.com/cloudposse/terraform-external-module-artifact.git?ref=tags/0.3.0"
+  source      = "git::https://github.com/cloudposse/terraform-external-module-artifact.git?ref=add-enabled"
   filename    = "lambda.zip"
   module_name = "terraform-aws-lambda-elasticsearch-cleanup"
   module_path = path.module

--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,7 @@ module "label" {
 module "artifact" {
   #source      = "git::https://github.com/cloudposse/terraform-external-module-artifact.git?ref=tags/0.3.0"
   source      = "git::https://github.com/cloudposse/terraform-external-module-artifact.git?ref=add-enabled"
+  enabled     = var.enabled
   filename    = "lambda.zip"
   module_name = "terraform-aws-lambda-elasticsearch-cleanup"
   module_path = path.module

--- a/main.tf
+++ b/main.tf
@@ -86,8 +86,7 @@ module "label" {
 }
 
 module "artifact" {
-  #source      = "git::https://github.com/cloudposse/terraform-external-module-artifact.git?ref=tags/0.3.0"
-  source      = "git::https://github.com/cloudposse/terraform-external-module-artifact.git?ref=add-enabled"
+  source      = "git::https://github.com/cloudposse/terraform-external-module-artifact.git?ref=tags/0.3.0"
   enabled     = var.enabled
   filename    = "lambda.zip"
   module_name = "terraform-aws-lambda-elasticsearch-cleanup"


### PR DESCRIPTION
## what
* Update `terraform-external-module-artifact` version

## why
* Add `enabled` variable to the module
* When the `terraform-external-module-artifact` module is used in this module with `enabled` variable set to `false`, `terraform-external-module-artifact` needs to be disabled as well (otherwise it throws errors that it can't download the artifact)

## references
* https://github.com/cloudposse/terraform-external-module-artifact/releases/tag/0.3.0
