### PR TITLE
Update github output syntax

### DIFF
--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -14,9 +14,9 @@ jobs:
         id: commit
         run: |
           if [[ '${{ github.ref }}' == 'refs/heads/master' ]]; then
-              echo "::set-output name=sha::${{ github.sha }}"
+              echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
           else
-              echo "::set-output name=sha::${{ github.event.pull_request.head.sha }}"
+              echo "sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
           fi
       # Checkout the pull request branch
       - name: Checkout code


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/